### PR TITLE
Use direct API calls; allocate instruments once

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,6 +18,7 @@ import (
 )
 
 func telemetryMW(log zerolog.Logger, tracer trace.Tracer, meter metric.Meter) func(next http.Handler) http.Handler {
+	// Allocate metric instruments. These only need to be allocated once per middleware.
 	counter := metric.Must(meter).NewInt64Counter("api.hit.count")
 	recorder := metric.Must(meter).NewInt64ValueRecorder("bytes.recieved")
 
@@ -39,7 +40,7 @@ func telemetryMW(log zerolog.Logger, tracer trace.Tracer, meter metric.Meter) fu
 			)
 			defer span.End()
 
-			// Metrics start
+			// Metrics
 			labels := []kv.KeyValue{kv.String("endpoint", path)}
 			meter.RecordBatch(ctx,
 				labels,

--- a/api/api.go
+++ b/api/api.go
@@ -18,6 +18,9 @@ import (
 )
 
 func telemetryMW(log zerolog.Logger, tracer trace.Tracer, meter metric.Meter) func(next http.Handler) http.Handler {
+	counter := metric.Must(meter).NewInt64Counter("api.hit.count")
+	recorder := metric.Must(meter).NewInt64ValueRecorder("bytes.recieved")
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			path := "api.endpoint:" + r.URL.EscapedPath() + ":" + r.Method
@@ -38,8 +41,6 @@ func telemetryMW(log zerolog.Logger, tracer trace.Tracer, meter metric.Meter) fu
 
 			// Metrics start
 			labels := []kv.KeyValue{kv.String("endpoint", path)}
-			counter := metric.Must(meter).NewInt64Counter("api.hit.count")
-			recorder := metric.Must(meter).NewInt64ValueRecorder("bytes.recieved")
 			meter.RecordBatch(ctx,
 				labels,
 				counter.Measurement(1),

--- a/version/service.go
+++ b/version/service.go
@@ -57,7 +57,7 @@ func (svc *Service) Add(ctx context.Context, a *Application) error {
 		errParams = append(errParams, "package")
 	}
 	if len(errParams) > 0 {
-		svc.Meterics.Meter.RecordBatch(ctx, []kv.KeyValue{kv.String("service.method", "Add")}, svc.Meterics.Instruments.ErrCounter.Measurement(1))
+		svc.Meterics.Instruments.ErrCounter.Add(ctx, 1, kv.String("service.method", "Add"))
 		return errs.E{Kind: errs.KindParameterErr, Parameters: errParams}
 	}
 
@@ -70,7 +70,7 @@ func (svc *Service) Add(ctx context.Context, a *Application) error {
 		return nil
 	}
 
-	svc.Meterics.Meter.RecordBatch(ctx, []kv.KeyValue{kv.String("service.method", "Add")}, svc.Meterics.Instruments.ErrCounter.Measurement(1))
+	svc.Meterics.Instruments.ErrCounter.Add(ctx, 1, kv.String("service.method", "Add"))
 	return err
 }
 
@@ -80,7 +80,7 @@ func (svc *Service) Get(ctx context.Context, id string) (Application, error) {
 
 	a, err := svc.store.Get(ctx, id)
 	if err != nil {
-		svc.Meterics.Meter.RecordBatch(ctx, []kv.KeyValue{kv.String("service.method", "Get")}, svc.Meterics.Instruments.ErrCounter.Measurement(1))
+		svc.Meterics.Instruments.ErrCounter.Add(ctx, 1, kv.String("service.method", "Get"))
 	}
 	return a, err
 }
@@ -90,7 +90,7 @@ func (svc *Service) UpdateVersion(ctx context.Context, a Application) error {
 	defer span.End()
 
 	if a.ID == "" {
-		svc.Meterics.Meter.RecordBatch(ctx, []kv.KeyValue{kv.String("service.method", "UpdateVersion")}, svc.Meterics.Instruments.ErrCounter.Measurement(1))
+		svc.Meterics.Instruments.ErrCounter.Add(ctx, 1, kv.String("service.method", "UpdateVersion"))
 		return errs.E{
 			Kind:    errs.KindInternal,
 			Wrapped: fmt.Errorf("given struct is missing ID"),
@@ -99,7 +99,7 @@ func (svc *Service) UpdateVersion(ctx context.Context, a Application) error {
 
 	aFrom, err := svc.store.Get(ctx, a.ID)
 	if err != nil {
-		svc.Meterics.Meter.RecordBatch(ctx, []kv.KeyValue{kv.String("service.method", "UpdateVersion")}, svc.Meterics.Instruments.ErrCounter.Measurement(1))
+		svc.Meterics.Instruments.ErrCounter.Add(ctx, 1, kv.String("service.method", "UpdateVersion"))
 		return err
 	}
 
@@ -115,7 +115,7 @@ func (svc *Service) List(ctx context.Context, limit int) ([]Application, error) 
 
 	applications, err := svc.store.List(ctx, limit)
 	if err != nil {
-		svc.Meterics.Meter.RecordBatch(ctx, []kv.KeyValue{kv.String("service.method", "List")}, svc.Meterics.Instruments.ErrCounter.Measurement(1))
+		svc.Meterics.Instruments.ErrCounter.Add(ctx, 1, kv.String("service.method", "List"))
 		return []Application{}, err
 	}
 


### PR DESCRIPTION
These changes are independent of the problem discussed in https://github.com/open-telemetry/opentelemetry-go/issues/875.

In both cases, the calls would be handled correctly, but either the performance or readability could be improved.